### PR TITLE
Check if primary model has type attribute using _normalizePolymorphicRecord

### DIFF
--- a/packages/ember-data/lib/serializers/rest-serializer.js
+++ b/packages/ember-data/lib/serializers/rest-serializer.js
@@ -336,7 +336,8 @@ var RESTSerializer = JSONSerializer.extend({
         ```
        */
       if (isPrimary && Ember.typeOf(value) !== 'array') {
-        let { data, included } = this._normalizePolymorphicRecord(store, value, prop, primaryModelClass, this);
+        let primaryHasTypeAttribute = get(primaryModelClass, 'attributes').get('type');
+        let { data, included } = this._normalizePolymorphicRecord(store, value, prop, primaryModelClass, this, primaryHasTypeAttribute);
         documentHash.data = data;
         if (included) {
           documentHash.included.push(...included);


### PR DESCRIPTION
In _normalizeResponse, check if primary model has type attribute using _normalizePolymorphicRecord.

Add the primaryHasTypeAttribute to the _normalizePolymorphicRecord call in rest-serializer's _normalizeResponse. Fixes bug if the primary model has a type property.